### PR TITLE
Change banner version via configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,13 @@ via the `VARNISH_CLI_BRIDGE_LISTEN_ADDRESS` environment variable or the
 Format is `[IP]:PORT` and the default is `127.0.0.1:6082` if not provided.
 Omitting the IP results in binding to all interfaces (ie `INADDR_ANY`).
 
+* Varnish banner: The text to include in the protocol banner response
+denoting the Varnish version. Can be specified via the
+`VARNISH_CLI_BRIDGE_BANNER_VERSION` ennvironment variable or the
+`-banner-version` command line argument, with the latter taking precedence.
+The recommended format is `varnish-[MAJOR].[MINOR].[BUILD] revision [REVISION]`
+but is not enforced. The default value is `varnish-3.0.0 revision 0000000`.
+
 ## Supported commands
 
 The Varnish CLI Bridge does not implement every command yet and some are not

--- a/main.go
+++ b/main.go
@@ -29,8 +29,6 @@ var (
 	listenAddress = "127.0.0.1:6082"
 	secretFile    string
 
-	// nexcess/magento-turpentine checks the banner text to determine the ban syntax
-	// TODO make version configurable, or query from section.io API
 	bannerVarnishVersion = "varnish-3.0.0 revision 0000000"
 
 	// eg "https://aperture.section.io/api/v1/account/1/application/1/"
@@ -95,6 +93,13 @@ func configure() {
 	}
 	flag.StringVar(&secretFile, "secret-file", secretFile,
 		"Path to file containing the Varnish CLI authentication secret.")
+
+	envBannerVarnishVersion := os.Getenv(cliEnvKeyPrefix + "BANNER_VERSION")
+	if envBannerVarnishVersion != "" {
+		bannerVarnishVersion = envBannerVarnishVersion
+	}
+	flag.StringVar(&bannerVarnishVersion, "banner-version", bannerVarnishVersion,
+		"Varnish version text to include in the protocol banner text.")
 
 	envApiEndpoint := os.Getenv(sectionioEnvKeyPrefix + "API_ENDPOINT")
 	if envApiEndpoint != "" {


### PR DESCRIPTION
Add a environment variable and command line argument to specify an
alternate Varnish version in the banner test returned in the protocol in
response to successful authentication and `banner` requests.
